### PR TITLE
comment weak function HAL_InitTick()

### DIFF
--- a/source/stm32f0xx_hal.c
+++ b/source/stm32f0xx_hal.c
@@ -235,17 +235,18 @@ __weak void HAL_MspDeInit(void)
   * @param TickPriority: Tick interrupt priority.
   * @retval HAL status
   */
-__weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
-{
-  /*Configure the SysTick to have interrupt in 1ms time basis*/
-  HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
-
-  /*Configure the SysTick IRQ priority */
-  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority ,0);
-
-   /* Return function status */
-  return HAL_OK;
-}
+#warning "The weak HAL_InitTick() is commented to enforce use of definition in hal_tick.c. Unclear why necessary."
+//__weak HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
+//{
+//  /*Configure the SysTick to have interrupt in 1ms time basis*/
+//  HAL_SYSTICK_Config(HAL_RCC_GetHCLKFreq()/1000);
+//
+//  /*Configure the SysTick IRQ priority */
+//  HAL_NVIC_SetPriority(SysTick_IRQn, TickPriority ,0);
+//
+//   /* Return function status */
+//  return HAL_OK;
+//}
 
 /**
   * @}


### PR DESCRIPTION
For any reason it is necessary to comment that function here otherwise the definition in hal_tick.c is not used.
