### PR TITLE
Fix for the dependency of uvisor-lib

### DIFF
--- a/module.json
+++ b/module.json
@@ -18,7 +18,7 @@
     "mbed-hal-st-stm32cubef0"
   ],
   "dependencies": {
-    "uvisor-lib": "^1.0.0",
+    "uvisor-lib": ">=1.0.0,<3.0.0",
     "mbed-hal-st-stm32f0": "tridonic-com/mbed-hal-st-stm32f0#b0.3.1-tri-0.5.0"
   },
   "targetDependencies": {}


### PR DESCRIPTION
- Aligned uvisor-lib dependency with F4 (the fix in https://github.com/tridonic-com/mbed-hal-st-stm32f0/commit/1af36bcd90ed2977c42572597beb195bcc131a3b was not enough)
