### PR TITLE
Workaround for a deadlock caused by a check of a tick value in interrupt context

### DIFF
--- a/source/stm32f0xx_hal_i2c.c
+++ b/source/stm32f0xx_hal_i2c.c
@@ -4035,10 +4035,11 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
     {
         /*
          * Introduced a partial fix for exiting this loop even when in an interrupt context
-         * I verified that checkTickerCounter=289 for Timeout=1. Thus 289
-         * Thus I consider that checkTickerCounter should be greater than Timeout*300 to exit the cycle.
+         * I verified that checkTickerCounter=289 for Timeout=1.
+         * I enlarge it by 10% (*110/100)
+         * Thus I consider that checkTickerCounter should be greater than Timeout*289*110/100 to exit the cycle.
          */
-      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout) || (checkTickerCounter > Timeout*300))
+      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout) || (checkTickerCounter > Timeout*289*110/100))
       {
         hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
         hi2c->State= HAL_I2C_STATE_READY;

--- a/source/stm32f0xx_hal_i2c.c
+++ b/source/stm32f0xx_hal_i2c.c
@@ -4015,7 +4015,7 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
   temp_for_debug = 0;
   checkTickerCounter = 0;
   
-  while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET))// || checkTickerCounter < 2^31)
+  while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET))
   {
     /* Check if a NACK is detected */
     if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)


### PR DESCRIPTION
- Checking the value in interrupt context prevents the tick from being changed by an interrupt that is executing at the same level of priority. Introduced a partial fix, as a workaround we count on a variable the amount of times the cycle is being run.
