### PR TITLE
Revert "Workaround for a deadlock caused by a check of a tick value i…

### DIFF
--- a/source/stm32f0xx_hal_i2c.c
+++ b/source/stm32f0xx_hal_i2c.c
@@ -4010,13 +4010,8 @@ static HAL_StatusTypeDef I2C_WaitOnFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uin
 static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c, uint32_t Timeout)  
 {  
   uint32_t tickstart = HAL_GetTick();
-  uint32_t checkTickerCounter;
-  uint8_t temp_for_debug;
 
-  temp_for_debug = 0;
-  checkTickerCounter = 0;
-  
-  while((__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET))
+  while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_TXIS) == RESET)
   {
     /* Check if a NACK is detected */
     if(I2C_IsAcknowledgeFailed(hi2c, Timeout) != HAL_OK)
@@ -4024,29 +4019,16 @@ static HAL_StatusTypeDef I2C_WaitOnTXISFlagUntilTimeout(I2C_HandleTypeDef *hi2c,
       return HAL_ERROR;
     }
 
-    /* Increment counter as a partial solution for the
-     * https://git.dev.zgrp.net/stc/tri-stc-driver-acdc/issues/9 problem */
-    checkTickerCounter++;
-
     /* Check for the Timeout */
     if(Timeout != HAL_MAX_DELAY)
     {
-        /*
-         * Introduced a partial fix for exiting this loop even when in an interrupt context
-         * I verified that checkTickerCounter=289 for Timeout=1.
-         * I enlarge it by 10% (*110/100)
-         * Thus I consider that checkTickerCounter should be greater than Timeout*289*110/100 to exit the cycle.
-         */
-      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout) || (checkTickerCounter > Timeout*289*110/100))
+      if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout))
       {
         hi2c->ErrorCode |= HAL_I2C_ERROR_TIMEOUT;
         hi2c->State= HAL_I2C_STATE_READY;
 
         /* Process Unlocked */
         __HAL_UNLOCK(hi2c);
-
-        checkTickerCounter++; // ADDED FOR TEST
-        temp_for_debug++; // ADDED FOR TEST
 
         return HAL_TIMEOUT;
       }
@@ -4149,13 +4131,6 @@ static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32
   uint32_t tickstart = 0x00;
   tickstart = HAL_GetTick();
 
-  uint32_t checkTickerCounter;
-  uint8_t temp_for_debug;
-
-  temp_for_debug = 0;
-  checkTickerCounter = 0;
-
-
   if(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_AF) == SET)		// not acknowledge received ?
   {
     /* Generate stop if necessary only in case of I2C peripheral in MASTER mode */
@@ -4175,21 +4150,10 @@ static HAL_StatusTypeDef I2C_IsAcknowledgeFailed(I2C_HandleTypeDef *hi2c, uint32
     /* AutoEnd should be initiate after AF */
     while(__HAL_I2C_GET_FLAG(hi2c, I2C_FLAG_STOPF) == RESET)
     {
-      /* Increment counter as a partial solution for the
-       * https://git.dev.zgrp.net/stc/tri-stc-driver-acdc/issues/9 problem */
-       checkTickerCounter++;
-
       /* Check for the Timeout */
       if(Timeout != HAL_MAX_DELAY)
       {
-        /*
-         * Introduced a partial fix for exiting this loop even when in an interrupt context
-         * I verified that checkTickerCounter=289 for Timeout=1 (for the I2C_WaitOnTXISFlagUntilTimeout function).
-         * Did not try better on this function. As a safety measure, I multiply by 100%
-         * I enlarge it by 100% (*200/100)
-         * Thus I consider that checkTickerCounter should be greater than Timeout*289*200/100 to exit the cycle.
-         */
-        if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout) || (checkTickerCounter > Timeout*289*200/100))
+        if((Timeout == 0) || ((HAL_GetTick() - tickstart) > Timeout))
         {
           hi2c->State= HAL_I2C_STATE_READY;
           /* Process Unlocked */


### PR DESCRIPTION
…n interrupt context"

This reverts commit 4d7fc051f62d92e1c2ef511984edf767df961948.
# Conflicts:
# source/stm32f0xx_hal_i2c.c
